### PR TITLE
Fabo/release GitHub

### DIFF
--- a/pending/fabo_release-github
+++ b/pending/fabo_release-github
@@ -1,0 +1,1 @@
+[Added] Allow to store releases on GitHub via `store-release` @faboweb

--- a/src/cli.js
+++ b/src/cli.js
@@ -108,7 +108,13 @@ releaseCommonOptions(program.command("release-candidate"))
     }
   });
 
-releaseCommonOptions(program.command("store-release"))
+program
+  .command("store-release")
+  .option(
+    "-c, --changelog-path <changelog path>",
+    "Where is the changelog located?",
+    "./CHANGELOG.md"
+  )
   .option(
     "-o, --owner <owner>",
     "Name of the owner or organization of the repository. (guessed from origin if empty)"

--- a/src/cli.js
+++ b/src/cli.js
@@ -6,6 +6,7 @@ const { createReleaseCandidate } = require("./release-candidate");
 const { logChanges } = require("./add-pending");
 const { checkPendingAdded } = require("./pending-added-check");
 const { getNewVersion } = require("./version");
+const { storeRelease } = require("./store-release");
 
 function noChanges(pendingPath) {
   console.log(
@@ -105,6 +106,40 @@ releaseCommonOptions(program.command("release-candidate"))
     if (!changes) {
       noChanges(options.pendingPath);
     }
+  });
+
+releaseCommonOptions(program.command("store-release"))
+  .option(
+    "-o, --owner <owner>",
+    "Name of the owner or organization of the repository. (guessed from origin if empty)"
+  )
+  .option(
+    "-r, --repository <repository>",
+    "Name of the repo. (guessed from origin if empty)"
+  )
+  .option(
+    "-t, --token <github auth token>",
+    "Token to authenticate to GitHub (to push chages)."
+  )
+  .option("-v, --tag <tag>", "Tag for version to store in GitHub")
+  .option("-x, --tag-prefix <prefix>", "Prefix version tags")
+  .action(async function(options) {
+    const token = options.token || process.env.GITHUB_ACCESS_TOKEN;
+    if (!token) {
+      console.error(
+        "To store a release, you need to provide a GitHub access token via '--token' or by setting the environment variable GITHUB_ACCESS_TOKEN."
+      );
+      return;
+    }
+
+    await storeRelease(
+      options.tag,
+      options.tagPrefix,
+      options.changelogPath,
+      options.token,
+      options.owner,
+      options.repository
+    );
   });
 
 program

--- a/src/store-release.js
+++ b/src/store-release.js
@@ -1,0 +1,72 @@
+const { promisify } = require(`util`);
+const exec = promisify(require(`child_process`).exec);
+const axios = require("axios");
+const fs = require("fs");
+
+async function uploadRelease({ tag, textContent, owner, repo, token }) {
+  axios.defaults.headers.common["Authorization"] = `token ${token}`;
+  await axios
+    .post(`https://api.github.com/repos/${owner}/${repo}/releases`, {
+      name: `Release ${tag}`,
+      body: textContent,
+      tag_name: tag
+    })
+    .catch(err => {
+      console.error(err);
+      throw err;
+    });
+}
+
+async function storeRelease(tag, tagPrefix, changelogPath, token, owner, repo) {
+  if (!owner || !repo) {
+    if (process.env.GITHUB_REPOSITORY) {
+      console.log(
+        "Guessing GitHub repository from remote environment variable."
+      );
+      owner = process.env.GITHUB_REPOSITORY.split("/")[0];
+      repo = process.env.GITHUB_REPOSITORY.split("/")[1];
+    } else {
+      console.log("Guessing GitHub repository from remote 'origin'.");
+      const origin = (await exec("git remote get-url origin")).stdout.trim();
+      const match = /https:\/\/github\.com\/(.+)\/(.+)\.git/.exec(origin);
+      if (match.length === 0) {
+        console.error("Git remote 'origin' is not a GitHub repository");
+        return { changes: null };
+      }
+      owner = match[1];
+      repo = match[2];
+    }
+  }
+
+  const changeLog = fs.readFileSync(changelogPath, `utf8`);
+  let version = tagPrefix ? tag.replace(tagPrefix + "-", "") : tag;
+  version = tag.replace("v", "");
+
+  // match from version tag until next version tag or end of file
+  // 1st group version title "## [0.0.22] - 2020-06-11"
+  // 2nd group content
+  // 3rd group next version title or end of file
+
+  // console.log(`(## \\[${version.replace(/\./g,`\\.`)}\] - \\S+\\n)([\\s\\S]+)(## \\[|\\z)`)
+  // return
+  const versions = changeLog.split("## ["); // header tag for versions
+  const versionSection = versions.find(record => record.startsWith(version));
+  if (!versionSection)
+    throw new Error(`No changelog entry found for version ${version}`);
+  const versionSectionBody = versionSection
+    .substr(versionSection.indexOf("\n"))
+    .trim();
+
+  console.log("Creating Release");
+  await uploadRelease({
+    textContent: versionSectionBody,
+    token,
+    tag,
+    owner,
+    repo
+  });
+}
+
+module.exports = {
+  storeRelease
+};


### PR DESCRIPTION
Usage: store-release [options]

Options:
  -c, --changelog-path <changelog path>  Where is the changelog located? (default: "./CHANGELOG.md")
  -o, --owner <owner>                    Name of the owner or organization of the repository. (guessed from origin if empty)       
  -r, --repository <repository>          Name of the repo. (guessed from origin if empty)
  -t, --token <github auth token>        Token to authenticate to GitHub (to push chages).
  -v, --tag <tag>                        Tag for version to store in GitHub
  -x, --tag-prefix <prefix>              Prefix version tags
  -h, --help                             output usage information